### PR TITLE
Fixing audio player

### DIFF
--- a/dorian.epmi
+++ b/dorian.epmi
@@ -25,9 +25,9 @@
           <datasetid>document</datasetid>
           <filename>citations/eprint/dorian.xml</filename>
           <mime_type>application/xml</mime_type>
-          <hash>ce28cba8e4dfe6de40244ec98439bd3b</hash>
+          <hash>567b894856f263aaefce678271d1ad36</hash>
           <hash_type>MD5</hash_type>
-          <filesize>14055</filesize>
+          <filesize>14185</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -57,9 +57,9 @@
           <datasetid>document</datasetid>
           <filename>static/style/auto/zz_dorian.css</filename>
           <mime_type>text/plain</mime_type>
-          <hash>13fcc9cfb4e8613cfef4a3a5462977e3</hash>
+          <hash>58ecc7c32bb3e2562867a1fb1f650c3d</hash>
           <hash_type>MD5</hash_type>
-          <filesize>2827</filesize>
+          <filesize>2879</filesize>
         </file>
       </files>
       <mime_type>text/plain</mime_type>
@@ -78,7 +78,7 @@
       <id>you@email.address</id>
     </item>
   </creators>
-  <datestamp>2019-11-11 17:21:40</datestamp>
+  <datestamp>2019-11-15 11:20:03</datestamp>
   <title>Dorian</title>
   <description>This is the description.</description>
   <requirements>The following modules are required: X, Y, Z</requirements>

--- a/lib/citations/eprint/dorian.xml
+++ b/lib/citations/eprint/dorian.xml
@@ -80,15 +80,13 @@
   <epc:set name='audios' expr="$item.get_type('audio')">
   <div id="Audio" class="dorian-container dorian-border dorian-panel" style="display:none">
         <epc:foreach expr="$audios" iterator="audio">
-          <div class="plyr_container">
-		    <video poster="" id="audio_plyr_{$index}" playsinline="true" controls="true"
-			data-doc-title="{$audio.property('main')}"
-			class="audio">
+          <div class="plyr plyr--full-ui plyr--audio">
+              <audio id="audio_plyr_{$index}" controls="true">
 	     		<source src="{$audio.url()}" type="{$audio.property('mime_type')}" />
-     		</video>
-	      </div>
+     		</audio>
+            </div>
         </epc:foreach>
-    <!-- <epc:comment> Maybe do embedding of audio services... maybe sound cloud. Not supported by plyr, but maybe a default soundcloud iframe 
+    <!-- <epc:comment> TEST Maybe do embedding of audio services... maybe sound cloud. Not supported by plyr, but maybe a default soundcloud iframe 
 	<epc:if test="$item.property('official_url') and $item.url_is_audio('official_url')">
 	    <div class="plyr__video-embed" id="player_official_url">
 		<iframe
@@ -304,11 +302,11 @@ jQuery(function() {
     	});
    	//check a url that we think is an embedable videos  (no need for plyr+_config for 3rd party vids)
     	if(jQuery('#player_official_url').length>0){
-		new Plyr('#player_official_url');
+		    new Plyr('#player_official_url');
     	}
 
-    	jQuery('.audio').each( function(ind) {
-		init_plyr(this,ind);
+    	jQuery('audio').each( function(ind) {
+		    init_plyr(this,ind);
     	});
 	
 	function init_plyr(el, index){

--- a/lib/citations/eprint/dorian.xml
+++ b/lib/citations/eprint/dorian.xml
@@ -80,7 +80,12 @@
   <epc:set name='audios' expr="$item.get_type('audio')">
   <div id="Audio" class="dorian-container dorian-border dorian-panel" style="display:none">
         <epc:foreach expr="$audios" iterator="audio">
-          <div class="plyr plyr--full-ui plyr--audio">
+            <div class="dorian_audio_file_name">
+                <br/>
+                <epc:print expr="$index"/> - <print expr="$audio.property('main')"/>
+                <br/>
+            </div>
+          <div class="plyr_container">
               <audio id="audio_plyr_{$index}" controls="true">
 	     		<source src="{$audio.url()}" type="{$audio.property('mime_type')}" />
      		</audio>

--- a/lib/static/style/auto/zz_dorian.css
+++ b/lib/static/style/auto/zz_dorian.css
@@ -144,3 +144,7 @@ div.downloads_grid {
 	  padding-top: 100px;
 	}
 }
+
+.dorian_audio_file_name{
+    padding-left: 10px;
+}


### PR DESCRIPTION
Ensured that the correct Plyr audio player displays when the item contains audio files.
The name of file is displayed at the top of the audio player, together with an index.