### PR TITLE
Citation refactored

### DIFF
--- a/dorian.epmi
+++ b/dorian.epmi
@@ -23,11 +23,123 @@
         </file>
         <file>
           <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_main_tabs_box.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>bf29a622c1cf2d74f7c43d5188efaebc</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>771</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_downloads_section.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>1da29d6beb5344851ce2413238333f6b</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>2235</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_images.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>5cf503c438cf2042a6b9aa7cfdf9dfc3</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>319</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_plyr_player.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>6ac4477c3f328f26821ff374ae63e6f6</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>1295</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_tab_controls.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>e22f38bc1be3eac211e8a3089e69eca0</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>1454</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_metadata_section.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>dcc49e96785dff7f2265f264725754e7</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>3744</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_videos.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>0d03bc4d901eaa058dcf08b4e1ed7d69</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>370</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_audio_players_section.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>77b6ae6c639d86469745e4258460109c</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>1355</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_dependencies.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>883eb2f12fcf5c5544df63c2c32a5a48</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>319</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_downloads.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>22f1ff51db369ac82519ff9caa6aafeb</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>474</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_images_section.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>3238cef3b8d6df9c72bf6ac2cdfab110</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>811</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
           <filename>citations/eprint/dorian.xml</filename>
           <mime_type>application/xml</mime_type>
-          <hash>567b894856f263aaefce678271d1ad36</hash>
+          <hash>ca86472e6cb4b32a7fe45e82634790a9</hash>
           <hash_type>MD5</hash_type>
-          <filesize>14185</filesize>
+          <filesize>320</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_audios.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>ee7d4dbee4e239cb8f173cd0aec68c48</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>325</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_photoswipe.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>512f3e4584ab38b6f73d25bd570af480</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>2642</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_video_players_section.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>5f33d7a9b2f7138d09e179efb9624fc7</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>1415</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -78,7 +190,7 @@
       <id>you@email.address</id>
     </item>
   </creators>
-  <datestamp>2019-11-15 11:20:03</datestamp>
+  <datestamp>2019-11-15 12:49:06</datestamp>
   <title>Dorian</title>
   <description>This is the description.</description>
   <requirements>The following modules are required: X, Y, Z</requirements>

--- a/lib/citations/eprint/dorian.xml
+++ b/lib/citations/eprint/dorian.xml
@@ -29,19 +29,7 @@
 
 <!-- IMAGES --> 
 <epc:if test="$item.has_type('image')">
-  <epc:set name='images' expr="$item.get_type('image')">
-  <div id="Images" class="dorian-container dorian-border dorian-panel">
-    <div id="image_container" class="free-wall picture">
-        <epc:foreach expr="$images" iterator="image">
-          <div class="item brick">
-		  <a href="{$image.url()}" itemprop="contentUrl" data-size="{$image.property('media_width')}x{$image.property('media_height')}">
-			<img src="{$image.thumbnail_url('preview')}" itemprop="thumbnail" alt="Image description" data-index="{$index}" />
-              </a>
-          </div>
-        </epc:foreach>
-    </div>
-  </div>
-  </epc:set>
+    <epc:print expr="$item.citation('dorian_images_section')"/>
 </epc:if>
 
 <!-- VIDEO SECTION -->

--- a/lib/citations/eprint/dorian.xml
+++ b/lib/citations/eprint/dorian.xml
@@ -242,91 +242,9 @@
 
 </div> <!-- end of tabbed stuff -->
 
-<!-- Photoswipe container for slide show-->
-<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
-    <!-- Background of PhotoSwipe. 
-         It's a separate element as animating opacity is faster than rgba(). -->
-    <div class="pswp__bg"></div>
-    <!-- Slides wrapper with overflow:hidden. -->
-    <div class="pswp__scroll-wrap">
-        <!-- Container that holds slides. 
-            PhotoSwipe keeps only 3 of them in the DOM to save memory.
-            Don't modify these 3 pswp__item elements, data is added later on. -->
-        <div class="pswp__container">
-            <div class="pswp__item"></div>
-            <div class="pswp__item"></div>
-            <div class="pswp__item"></div>
-        </div>
-        <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
-        <div class="pswp__ui pswp__ui--hidden">
-            <div class="pswp__top-bar">
-                <!--  Controls are self-explanatory. Order can be changed. -->
-                <div class="pswp__counter"></div>
-                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
-                <button class="pswp__button pswp__button--share" title="Share"></button>
-                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
-                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+<epc:print expr="$item.citation('dorian_photoswipe')"/>
 
-                <!-- Preloader demo https://codepen.io/dimsemenov/pen/yyBWoR -->
-                <!-- element will get class pswp__preloader - - active when preloader is running -->
-                <div class="pswp__preloader">
-                    <div class="pswp__preloader__icn">
-                      <div class="pswp__preloader__cut">
-                        <div class="pswp__preloader__donut"></div>
-                      </div>
-                    </div>
-                </div>
-            </div>
-            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
-                <div class="pswp__share-tooltip"></div>
-            </div>
-            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"> </button>
-            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"> </button>
-            <div class="pswp__caption">
-                <div class="pswp__caption__center"></div>
-            </div>
-        </div>
-    </div>
-</div>
-
-<script type="text/javascript">
-//<![CDATA[
-const VE_CONFIG = {};
-//]]>
-VE_CONFIG.use_images_as_posters = false;
-<epc:if test="$config{dorian}{use_images_as_posters} = 'TRUE'">
-VE_CONFIG.use_images_as_posters = true;
-</epc:if>
-
-//<![CDATA[
-
-jQuery(function() {
-
-	jQuery('.video').each( function(ind) {
-		init_plyr(this, ind);
-    	});
-   	//check a url that we think is an embedable videos  (no need for plyr+_config for 3rd party vids)
-    	if(jQuery('#player_official_url').length>0){
-		    new Plyr('#player_official_url');
-    	}
-
-    	jQuery('audio').each( function(ind) {
-		    init_plyr(this,ind);
-    	});
-	
-	function init_plyr(el, index){
-		const plyr_config = {};
-		plyr_config.title = jQuery(el).data("doc-title");
-		//use the image with same index for poster
-		if( VE_CONFIG.use_images_as_posters && jQuery('.picture a img').length > 0 &&  jQuery('.picture a img').eq(index) !== undefined){
-			jQuery(el).attr("poster", jQuery('.picture a img').eq(index).attr("src"));
-		}
-		//		console.log("plyr_config: ",plyr_config);
-		new Plyr('#'+jQuery(el).attr("id"), plyr_config );	
-	}
-});
-//]]>
-</script>
+<epc:print expr="$item.citation('dorian_plyr_player')"/>
 
 </cite:citation>
 

--- a/lib/citations/eprint/dorian.xml
+++ b/lib/citations/eprint/dorian.xml
@@ -44,35 +44,8 @@
   </epc:set>
 </epc:if>
 
-<!-- VIDEO -->
 <epc:if test="$item.has_type('video') or $item.url_is_video('official_url')">
-  <epc:set name='videos' expr="$item.get_type('video')">
-     <div id="Video" class="dorian-container dorian-border dorian-panel" style="display:none">
-	<!-- LOOP THROUGH ITEM VIDEO FILES and youtube/vimeo urls -->
-        <epc:foreach expr="$videos" iterator="video">
-          <div class="plyr_container">
-		<video id="plyr_{$index}" playsinline="true" controls="true" 
-			data-doc-title="{$video.property('main')}"
-			class="video">
-	     <source src="{$video.url()}" type="{$video.property('mime_type')}" />
-	       <!-- Captions are optional -->
-	       <!-- <track kind="captions" label="English captions" src="/path/to/captions.vtt" srclang="en" default />-->
-              </video>
-	  </div>
-        </epc:foreach>
-	<epc:if test="$item.property('official_url') and $item.url_is_video('official_url')">
-          <div class="plyr_container">
-	    <div class="plyr__video-embed" id="player_official_url">
-		<iframe
-			src="{$item.url_to_embed('official_url')}"
-		    allowfullscreen="true"
-		    allowtransparency="true"
-		    allow="autoplay"></iframe>
-	     </div>
-	   </div>
-	 </epc:if>
-     </div>
-  </epc:set> 
+    <epc:print expr="$item.citation('dorian_video_players_section')"/>
 </epc:if>
 
 <epc:if test="$item.has_type('audio')">

--- a/lib/citations/eprint/dorian.xml
+++ b/lib/citations/eprint/dorian.xml
@@ -44,147 +44,24 @@
   </epc:set>
 </epc:if>
 
+<!-- VIDEO SECTION -->
 <epc:if test="$item.has_type('video') or $item.url_is_video('official_url')">
     <epc:print expr="$item.citation('dorian_video_players_section')"/>
 </epc:if>
 
+<!-- AUDIO SECTION -->
 <epc:if test="$item.has_type('audio')">
     <epc:print expr="$item.citation('dorian_audio_players_section')"/>
 </epc:if>
 
 <!-- DOWNLOADS AKA everything else -->
 <epc:if test="$item.has_docs() and ($item.has_type('image') or $item.has_type('video') or $item.has_type('audio'))">
-    <!-- if we have docs either multimedia or additional to mm we have a dowloads panel -->
-  <div id="Downloads" class="dorian-container dorian-border dorian-panel" style="display:none">
-     <div class="downloads_container">
-      <epc:set name='docs' expr='$item.documents()'>
-        <epc:if test="length($docs) = 0">
-          <epc:phrase ref="page:nofulltext" />
-          <epc:if test="$item.contact_email().is_set() and eprint_status = 'archive'">
-            (<a href="{$config{http_cgiurl}}/request_doc?eprintid={eprintid}"><epc:phrase ref="request:button" /></a>)
-          </epc:if>
-        </epc:if>
-      
-        <epc:if test="length($docs) gt 0">
-          <epc:phrase ref="page:fulltext" />
-		<div class="downloads_grid">
-		 <epc:foreach expr="$docs" iterator="doc">
-		  <a href="{$doc.url()}">
-		    <figure>
-<!--		      <epc:print expr="$doc.icon('HoverPreview','noNewWindow')}" /> -->
-		      <epc:print expr="$doc.icon()" />
-		      <figcaption>
-			  <epc:print expr="$doc.citation('default')" /><br />
-			  <a href="{$doc.url()}" class="ep_document_link"><epc:phrase ref="summary_page:download"/> (<epc:print expr="$doc.doc_size().human_filesize()" />)</a>
-			  <epc:if test="!$doc.is_public() and $item.contact_email().is_set() and eprint_status = 'archive'">
-			    | <a href="{$config{http_cgiurl}}/request_doc?docid={$doc{docid}"><epc:phrase ref="request:button" /></a>
-			  </epc:if>
-		      </figcaption>
-		    </figure>
-		  </a>
-		 </epc:foreach>
-         	<epc:if test="iiif_manifest_enabled()">
-		  <a href="{$config{http_cgiurl}}/export/eprint/{$item.property('eprintid')}/IIIFManifest/nuatest-eprint-{$item.property('eprintid')}.js">
-		   <figure>
-	  	     <img src="{$config{rel_path}}/images/International_Image_Interoperability_Framework_logo.png" width="68px"/>
-		     <figcaption>
-			Export IIIF Manifest
-			<br/>
-			<a href="https://iiif.io/about/">What is IIIF?</a>
-		     </figcaption>
-		   </figure>
-	      	 </a>
-         	</epc:if>
-		</div>
-        </epc:if>
-      </epc:set>
-    </div>
-  </div>
+    <epc:print expr="$item.citation('dorian_downloads_section')"/>
 </epc:if>
 
-<!-- METADATA -->
+<!-- METADATA SECTION -->
 
- <div id="Metadata" class="dorian-container dorian-border dorian-panel" style="display:none">
-
-   <div class="metadata_container">
-
-    <epc:if test="!$item.has_type('image') and !$item.has_type('video') !$item.has_type('audio') ">
-    <!-- we only have downloadable docs? just show trad. EPrints page (no bar) -->
-      <epc:set name='docs' expr='$item.documents()'>
-
-        <epc:if test="length($docs) = 0">
-          <epc:phrase ref="page:nofulltext" />
-          <epc:if test="$item.contact_email().is_set() and eprint_status = 'archive'">
-            (<a href="{$config{http_cgiurl}}/request_doc?eprintid={eprintid}"><epc:phrase ref="request:button" /></a>)
-          </epc:if>
-        </epc:if>
-      
-        <epc:if test="length($docs) gt 0">
-          <epc:phrase ref="page:fulltext" />
-          <table>
-            <epc:foreach expr="$docs" iterator="doc">
-              <tr>
-                <td valign="top" align="right"><epc:print expr="$doc.icon('HoverPreview','noNewWindow')}" /></td>
-                <td valign="top">
-                  <epc:print expr="$doc.citation('default')" /><br />
-                  <a href="{$doc.url()}" class="ep_document_link"><epc:phrase ref="summary_page:download"/> (<epc:print expr="$doc.doc_size().human_filesize()" />)</a>
-                  <epc:if test="!$doc.is_public() and $item.contact_email().is_set() and eprint_status = 'archive'">
-                    | <a href="{$config{http_cgiurl}}/request_doc?docid={$doc{docid}"><epc:phrase ref="request:button" /></a>
-                  </epc:if>
-      
-                  <ul>
-                  <epc:foreach expr="$doc.related_objects('http://eprints.org/relation/hasVersion')" iterator="rel">
-                    <epc:if test="$rel{relation_type}!='http://eprints.org/relation/isVolatileVersionOf'">
-                      <li><epc:print expr="$rel.citation_link('default')" /></li>
-                    </epc:if>
-                  </epc:foreach>
-                  </ul>
-                </td>
-              </tr>
-            </epc:foreach>
-          </table>
-        </epc:if>
-
-      </epc:set>
-
-    </epc:if>
-
-
-  <table style="margin-bottom: 1em; margin-top: 1em;" cellpadding="3">
-      <epc:if test="official_url">
-        <tr>
-          <th align="right"><epc:phrase ref="eprint_fieldname_official_url" />:</th>
-          <td valign="top"><epc:print expr="official_url" /></td>
-        </tr>
-      </epc:if>
-    <tr>
-      <th align="right"><epc:phrase ref="eprint_fieldname_type" />:</th>
-      <td>
-        <epc:print expr="type" />
-        <epc:if test="type = 'conference_item'">(<epc:print expr="pres_type" />)</epc:if>
-        <epc:if test="type = 'monograph'">(<epc:print expr="monograph_type" />)</epc:if>
-        <epc:if test="type = 'thesis'">(<epc:print expr="thesis_type" />)</epc:if>
-      </td>
-    </tr>
-    <epc:comment> 
-       The below block loops over a list of field names taken from eprint_render.pl
-       Edit the list of metadata to show in the summary page table in eprint_render.pl
-    </epc:comment>
-    <epc:foreach expr="$config{summary_page_metadata}" iterator="fieldname">
-      <epc:if test="is_set($item.property($fieldname))">
-        <tr>
-          <th align="right"><epc:phrase ref="eprint_fieldname_{$fieldname}" />:</th>
-          <td valign="top"><epc:print expr="$item.property($fieldname)" /></td>
-        </tr>
-      </epc:if>
-    </epc:foreach>
-    <tr>
-      <th align="right">URI:</th>
-      <td valign="top"><a href="{$item.uri()}"><epc:print expr="$item.uri()" /></a></td>
-    </tr>
-  </table>
- </div>
- </div>
+<epc:print expr="$item.citation('dorian_metadata_section')"/>
 
 </div> <!-- end of tabbed stuff -->
 

--- a/lib/citations/eprint/dorian.xml
+++ b/lib/citations/eprint/dorian.xml
@@ -75,35 +75,8 @@
   </epc:set> 
 </epc:if>
 
-<!-- AUDIO -->
 <epc:if test="$item.has_type('audio')">
-  <epc:set name='audios' expr="$item.get_type('audio')">
-  <div id="Audio" class="dorian-container dorian-border dorian-panel" style="display:none">
-        <epc:foreach expr="$audios" iterator="audio">
-            <div class="dorian_audio_file_name">
-                <br/>
-                <epc:print expr="$index"/> - <print expr="$audio.property('main')"/>
-                <br/>
-            </div>
-          <div class="plyr_container">
-              <audio id="audio_plyr_{$index}" controls="true">
-	     		<source src="{$audio.url()}" type="{$audio.property('mime_type')}" />
-     		</audio>
-            </div>
-        </epc:foreach>
-    <!-- <epc:comment> TEST Maybe do embedding of audio services... maybe sound cloud. Not supported by plyr, but maybe a default soundcloud iframe 
-	<epc:if test="$item.property('official_url') and $item.url_is_audio('official_url')">
-	    <div class="plyr__video-embed" id="player_official_url">
-		<iframe
-			src="{$item.url_to_embed_audio('official_url')}"
-		    allowfullscreen="true"
-		    allowtransparency="true"
-		    allow="autoplay"></iframe>
-	    </div>
-	 </epc:if>
-	</epc:comment> 	-->
-  </div>
-  </epc:set> 
+    <epc:print expr="$item.citation('dorian_audio_players_section')"/>
 </epc:if>
 
 <!-- DOWNLOADS AKA everything else -->
@@ -243,7 +216,6 @@
 </div> <!-- end of tabbed stuff -->
 
 <epc:print expr="$item.citation('dorian_photoswipe')"/>
-
 <epc:print expr="$item.citation('dorian_plyr_player')"/>
 
 </cite:citation>

--- a/lib/citations/eprint/dorian.xml
+++ b/lib/citations/eprint/dorian.xml
@@ -6,26 +6,10 @@
 
 <cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
 
-  <div class="dorian-main">
+<div class="dorian-main">
 
-  <!-- TAB CONTROLS -->
-  <div class="dorian-bar ep-bg">
-        <epc:if test="$item.has_type('image')">
-            <button class="dorian-bar-item dorian-button tablink ep-fg" onclick="openTab(event,'Images')" data-panel="Images">Images</button>
-        </epc:if>
-        <epc:if test="$item.has_type('video') or $item.url_is_video('official_url')">
-            <button class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Video')" data-panel="Video">Video</button>
-        </epc:if>
-        <epc:if test="$item.has_type('audio')">
-            <button class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Audio')" data-panel="Audio">Audio</button>
-        </epc:if>
-        <epc:if test="$item.has_docs() and ($item.has_type('image') or $item.has_type('video') or $item.has_type('audio'))">
-            <button class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Downloads')" data-panel="Downloads">Downloads</button>
-        </epc:if>
-        <epc:if test="($item.has_docs() and ($item.has_type('image') or $item.has_type('video') or $item.has_type('audio'))) or $item.url_is_video('official_url'))">
-            <button id="Metadata-button" class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Metadata')" data-panel="Metadata">Metadata</button>
-        </epc:if>
-  </div>
+<!-- TAB CONTROLS: aka the buttons at the top of the media box -->
+<epc:print expr="$item.citation('dorian_tab_controls')"/>
 
 <!-- IMAGES --> 
 <epc:if test="$item.has_type('image')">

--- a/lib/citations/eprint/dorian_audio_players_section.xml
+++ b/lib/citations/eprint/dorian_audio_players_section.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" ?>
 
-<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:epc="http://eprints.org/ep3/control" 
+    xmlns:cite="http://eprints.org/ep3/citation" >
 
   <epc:set name='audios' expr="$item.get_type('audio')">
   <div id="Audio" class="dorian-container dorian-border dorian-panel" style="display:none">

--- a/lib/citations/eprint/dorian_audio_players_section.xml
+++ b/lib/citations/eprint/dorian_audio_players_section.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+
+  <epc:set name='audios' expr="$item.get_type('audio')">
+  <div id="Audio" class="dorian-container dorian-border dorian-panel" style="display:none">
+        <epc:foreach expr="$audios" iterator="audio">
+            <div class="dorian_audio_file_name">
+                <br/>
+                <epc:print expr="$index"/> - <print expr="$audio.property('main')"/>
+                <br/>
+            </div>
+          <div class="plyr_container">
+              <audio id="audio_plyr_{$index}" controls="true">
+	     		<source src="{$audio.url()}" type="{$audio.property('mime_type')}" />
+     		</audio>
+            </div>
+        </epc:foreach>
+    <!-- <epc:comment> TEST Maybe do embedding of audio services... maybe sound cloud. Not supported by plyr, but maybe a default soundcloud iframe 
+	<epc:if test="$item.property('official_url') and $item.url_is_audio('official_url')">
+	    <div class="plyr__video-embed" id="player_official_url">
+		<iframe
+			src="{$item.url_to_embed_audio('official_url')}"
+		    allowfullscreen="true"
+		    allowtransparency="true"
+		    allow="autoplay"></iframe>
+	    </div>
+	 </epc:if>
+	</epc:comment> 	-->
+  </div>
+  </epc:set> 
+
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_audios.xml
+++ b/lib/citations/eprint/dorian_audios.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
-
 <cite:citation xmlns="http://www.w3.org/1999/xhtml" 
     xmlns:epc="http://eprints.org/ep3/control" 
     xmlns:cite="http://eprints.org/ep3/citation" >
-
-    <epc:print expr="$item.citation('dorian_main_tabs_box')"/>
-    <epc:print expr="$item.citation('dorian_dependencies')"/>
-
+    <epc:if test="$item.has_type('audio')">
+        <epc:print expr="$item.citation('dorian_audio_players_section')"/>
+    </epc:if>
 </cite:citation>

--- a/lib/citations/eprint/dorian_dependencies.xml
+++ b/lib/citations/eprint/dorian_dependencies.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" ?>
-
 <cite:citation xmlns="http://www.w3.org/1999/xhtml" 
     xmlns:epc="http://eprints.org/ep3/control" 
     xmlns:cite="http://eprints.org/ep3/citation" >
-
-    <epc:print expr="$item.citation('dorian_main_tabs_box')"/>
-    <epc:print expr="$item.citation('dorian_dependencies')"/>
+    
+    <epc:print expr="$item.citation('dorian_photoswipe')"/>
+    <epc:print expr="$item.citation('dorian_plyr_player')"/>
 
 </cite:citation>

--- a/lib/citations/eprint/dorian_downloads.xml
+++ b/lib/citations/eprint/dorian_downloads.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:epc="http://eprints.org/ep3/control" 
+    xmlns:cite="http://eprints.org/ep3/citation" >
+
+    <epc:if test="  $item.has_docs() and 
+                    ($item.has_type('image') or 
+                        $item.has_type('video') or 
+                        $item.has_type('audio'))">
+        <epc:print expr="$item.citation('dorian_downloads_section')"/>
+    </epc:if>
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_downloads_section.xml
+++ b/lib/citations/eprint/dorian_downloads_section.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
 
-<!-- 
-	Full "abstract page" (or splash page or summary page, depending on your jargon) for an eprint. 
--->
-
-<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:epc="http://eprints.org/ep3/control" 
+    xmlns:cite="http://eprints.org/ep3/citation" >
 
     <!-- if we have docs either multimedia or additional to mm we have a dowloads panel -->
   <div id="Downloads" class="dorian-container dorian-border dorian-panel" style="display:none">

--- a/lib/citations/eprint/dorian_downloads_section.xml
+++ b/lib/citations/eprint/dorian_downloads_section.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+
+<!-- 
+	Full "abstract page" (or splash page or summary page, depending on your jargon) for an eprint. 
+-->
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+
+    <!-- if we have docs either multimedia or additional to mm we have a dowloads panel -->
+  <div id="Downloads" class="dorian-container dorian-border dorian-panel" style="display:none">
+     <div class="downloads_container">
+      <epc:set name='docs' expr='$item.documents()'>
+        <epc:if test="length($docs) = 0">
+          <epc:phrase ref="page:nofulltext" />
+          <epc:if test="$item.contact_email().is_set() and eprint_status = 'archive'">
+            (<a href="{$config{http_cgiurl}}/request_doc?eprintid={eprintid}"><epc:phrase ref="request:button" /></a>)
+          </epc:if>
+        </epc:if>
+      
+        <epc:if test="length($docs) gt 0">
+          <epc:phrase ref="page:fulltext" />
+		<div class="downloads_grid">
+		 <epc:foreach expr="$docs" iterator="doc">
+		  <a href="{$doc.url()}">
+		    <figure>
+<!--		      <epc:print expr="$doc.icon('HoverPreview','noNewWindow')}" /> -->
+		      <epc:print expr="$doc.icon()" />
+		      <figcaption>
+			  <epc:print expr="$doc.citation('default')" /><br />
+			  <a href="{$doc.url()}" class="ep_document_link"><epc:phrase ref="summary_page:download"/> (<epc:print expr="$doc.doc_size().human_filesize()" />)</a>
+			  <epc:if test="!$doc.is_public() and $item.contact_email().is_set() and eprint_status = 'archive'">
+			    | <a href="{$config{http_cgiurl}}/request_doc?docid={$doc{docid}"><epc:phrase ref="request:button" /></a>
+			  </epc:if>
+		      </figcaption>
+		    </figure>
+		  </a>
+		 </epc:foreach>
+         	<epc:if test="iiif_manifest_enabled()">
+		  <a href="{$config{http_cgiurl}}/export/eprint/{$item.property('eprintid')}/IIIFManifest/nuatest-eprint-{$item.property('eprintid')}.js">
+		   <figure>
+	  	     <img src="{$config{rel_path}}/images/International_Image_Interoperability_Framework_logo.png" width="68px"/>
+		     <figcaption>
+			Export IIIF Manifest
+			<br/>
+			<a href="https://iiif.io/about/">What is IIIF?</a>
+		     </figcaption>
+		   </figure>
+	      	 </a>
+         	</epc:if>
+		</div>
+        </epc:if>
+      </epc:set>
+    </div>
+  </div>
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_images.xml
+++ b/lib/citations/eprint/dorian_images.xml
@@ -3,8 +3,7 @@
 <cite:citation xmlns="http://www.w3.org/1999/xhtml" 
     xmlns:epc="http://eprints.org/ep3/control" 
     xmlns:cite="http://eprints.org/ep3/citation" >
-
-    <epc:print expr="$item.citation('dorian_main_tabs_box')"/>
-    <epc:print expr="$item.citation('dorian_dependencies')"/>
-
+    <epc:if test="$item.has_type('image')">
+        <epc:print expr="$item.citation('dorian_images_section')"/>
+    </epc:if>
 </cite:citation>

--- a/lib/citations/eprint/dorian_images_section.xml
+++ b/lib/citations/eprint/dorian_images_section.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" ?>
 
-<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:epc="http://eprints.org/ep3/control" 
+    xmlns:cite="http://eprints.org/ep3/citation" >
 
   <epc:set name='images' expr="$item.get_type('image')">
   <div id="Images" class="dorian-container dorian-border dorian-panel">

--- a/lib/citations/eprint/dorian_images_section.xml
+++ b/lib/citations/eprint/dorian_images_section.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+
+  <epc:set name='images' expr="$item.get_type('image')">
+  <div id="Images" class="dorian-container dorian-border dorian-panel">
+    <div id="image_container" class="free-wall picture">
+        <epc:foreach expr="$images" iterator="image">
+          <div class="item brick">
+		  <a href="{$image.url()}" itemprop="contentUrl" data-size="{$image.property('media_width')}x{$image.property('media_height')}">
+			<img src="{$image.thumbnail_url('preview')}" itemprop="thumbnail" alt="Image description" data-index="{$index}" />
+              </a>
+          </div>
+        </epc:foreach>
+    </div>
+  </div>
+  </epc:set>
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_main_tabs_box.xml
+++ b/lib/citations/eprint/dorian_main_tabs_box.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:epc="http://eprints.org/ep3/control" 
+    xmlns:cite="http://eprints.org/ep3/citation" >
+
+<div class="dorian-main">
+    <!-- TAB CONTROLS: aka the buttons at the top of the media box -->
+    <epc:print expr="$item.citation('dorian_tab_controls')"/>
+
+    <!-- FILE SECTIONS BY MIME TYPE --> 
+    <epc:print expr="$item.citation('dorian_images')"/>
+    <epc:print expr="$item.citation('dorian_videos')"/>
+    <epc:print expr="$item.citation('dorian_audios')"/>
+
+    <!-- DOWNLOADS AKA everything else -->
+    <epc:print expr="$item.citation('dorian_downloads')"/>
+
+    <!-- METADATA SECTION -->
+    <epc:print expr="$item.citation('dorian_metadata_section')"/>
+</div>
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_metadata_section.xml
+++ b/lib/citations/eprint/dorian_metadata_section.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+
+ <div id="Metadata" class="dorian-container dorian-border dorian-panel" style="display:none">
+
+   <div class="metadata_container">
+
+    <epc:if test="!$item.has_type('image') and !$item.has_type('video') !$item.has_type('audio') ">
+    <!-- we only have downloadable docs? just show trad. EPrints page (no bar) -->
+      <epc:set name='docs' expr='$item.documents()'>
+
+        <epc:if test="length($docs) = 0">
+          <epc:phrase ref="page:nofulltext" />
+          <epc:if test="$item.contact_email().is_set() and eprint_status = 'archive'">
+            (<a href="{$config{http_cgiurl}}/request_doc?eprintid={eprintid}"><epc:phrase ref="request:button" /></a>)
+          </epc:if>
+        </epc:if>
+      
+        <epc:if test="length($docs) gt 0">
+          <epc:phrase ref="page:fulltext" />
+          <table>
+            <epc:foreach expr="$docs" iterator="doc">
+              <tr>
+                <td valign="top" align="right"><epc:print expr="$doc.icon('HoverPreview','noNewWindow')}" /></td>
+                <td valign="top">
+                  <epc:print expr="$doc.citation('default')" /><br />
+                  <a href="{$doc.url()}" class="ep_document_link"><epc:phrase ref="summary_page:download"/> (<epc:print expr="$doc.doc_size().human_filesize()" />)</a>
+                  <epc:if test="!$doc.is_public() and $item.contact_email().is_set() and eprint_status = 'archive'">
+                    | <a href="{$config{http_cgiurl}}/request_doc?docid={$doc{docid}"><epc:phrase ref="request:button" /></a>
+                  </epc:if>
+      
+                  <ul>
+                  <epc:foreach expr="$doc.related_objects('http://eprints.org/relation/hasVersion')" iterator="rel">
+                    <epc:if test="$rel{relation_type}!='http://eprints.org/relation/isVolatileVersionOf'">
+                      <li><epc:print expr="$rel.citation_link('default')" /></li>
+                    </epc:if>
+                  </epc:foreach>
+                  </ul>
+                </td>
+              </tr>
+            </epc:foreach>
+          </table>
+        </epc:if>
+
+      </epc:set>
+
+    </epc:if>
+
+
+  <table style="margin-bottom: 1em; margin-top: 1em;" cellpadding="3">
+      <epc:if test="official_url">
+        <tr>
+          <th align="right"><epc:phrase ref="eprint_fieldname_official_url" />:</th>
+          <td valign="top"><epc:print expr="official_url" /></td>
+        </tr>
+      </epc:if>
+    <tr>
+      <th align="right"><epc:phrase ref="eprint_fieldname_type" />:</th>
+      <td>
+        <epc:print expr="type" />
+        <epc:if test="type = 'conference_item'">(<epc:print expr="pres_type" />)</epc:if>
+        <epc:if test="type = 'monograph'">(<epc:print expr="monograph_type" />)</epc:if>
+        <epc:if test="type = 'thesis'">(<epc:print expr="thesis_type" />)</epc:if>
+      </td>
+    </tr>
+    <epc:comment> 
+       The below block loops over a list of field names taken from eprint_render.pl
+       Edit the list of metadata to show in the summary page table in eprint_render.pl
+    </epc:comment>
+    <epc:foreach expr="$config{summary_page_metadata}" iterator="fieldname">
+      <epc:if test="is_set($item.property($fieldname))">
+        <tr>
+          <th align="right"><epc:phrase ref="eprint_fieldname_{$fieldname}" />:</th>
+          <td valign="top"><epc:print expr="$item.property($fieldname)" /></td>
+        </tr>
+      </epc:if>
+    </epc:foreach>
+    <tr>
+      <th align="right">URI:</th>
+      <td valign="top"><a href="{$item.uri()}"><epc:print expr="$item.uri()" /></a></td>
+    </tr>
+  </table>
+ </div>
+ </div>
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_photoswipe.xml
+++ b/lib/citations/eprint/dorian_photoswipe.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
 
-<!-- 
-	Full "abstract page" (or splash page or summary page, depending on your jargon) for an eprint. 
--->
-
-<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:epc="http://eprints.org/ep3/control" 
+    xmlns:cite="http://eprints.org/ep3/citation" >
 
 <!-- Photoswipe container for slide show-->
 <div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">

--- a/lib/citations/eprint/dorian_photoswipe.xml
+++ b/lib/citations/eprint/dorian_photoswipe.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+
+<!-- 
+	Full "abstract page" (or splash page or summary page, depending on your jargon) for an eprint. 
+-->
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+
+<!-- Photoswipe container for slide show-->
+<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+    <!-- Background of PhotoSwipe. 
+         It's a separate element as animating opacity is faster than rgba(). -->
+    <div class="pswp__bg"></div>
+    <!-- Slides wrapper with overflow:hidden. -->
+    <div class="pswp__scroll-wrap">
+        <!-- Container that holds slides. 
+            PhotoSwipe keeps only 3 of them in the DOM to save memory.
+            Don't modify these 3 pswp__item elements, data is added later on. -->
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+        <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
+        <div class="pswp__ui pswp__ui--hidden">
+            <div class="pswp__top-bar">
+                <!--  Controls are self-explanatory. Order can be changed. -->
+                <div class="pswp__counter"></div>
+                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+                <button class="pswp__button pswp__button--share" title="Share"></button>
+                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+
+                <!-- Preloader demo https://codepen.io/dimsemenov/pen/yyBWoR -->
+                <!-- element will get class pswp__preloader - - active when preloader is running -->
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                      <div class="pswp__preloader__cut">
+                        <div class="pswp__preloader__donut"></div>
+                      </div>
+                    </div>
+                </div>
+            </div>
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"> </button>
+            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"> </button>
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_plyr_player.xml
+++ b/lib/citations/eprint/dorian_plyr_player.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+
+<script type="text/javascript">
+//<![CDATA[
+const VE_CONFIG = {};
+//]]>
+VE_CONFIG.use_images_as_posters = false;
+<epc:if test="$config{dorian}{use_images_as_posters} = 'TRUE'">
+VE_CONFIG.use_images_as_posters = true;
+</epc:if>
+
+//<![CDATA[
+
+jQuery(function() {
+
+	jQuery('.video').each( function(ind) {
+		init_plyr(this, ind);
+    	});
+   	//check a url that we think is an embedable videos  (no need for plyr+_config for 3rd party vids)
+    	if(jQuery('#player_official_url').length>0){
+		    new Plyr('#player_official_url');
+    	}
+
+    	jQuery('audio').each( function(ind) {
+		    init_plyr(this,ind);
+    	});
+	
+	function init_plyr(el, index){
+		const plyr_config = {};
+		plyr_config.title = jQuery(el).data("doc-title");
+		//use the image with same index for poster
+		if( VE_CONFIG.use_images_as_posters && jQuery('.picture a img').length > 0 &&  jQuery('.picture a img').eq(index) !== undefined){
+			jQuery(el).attr("poster", jQuery('.picture a img').eq(index).attr("src"));
+		}
+		//		console.log("plyr_config: ",plyr_config);
+		new Plyr('#'+jQuery(el).attr("id"), plyr_config );	
+	}
+});
+//]]>
+</script>
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_tab_controls.xml
+++ b/lib/citations/eprint/dorian_tab_controls.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+
+<!-- 
+	Full "abstract page" (or splash page or summary page, depending on your jargon) for an eprint. 
+-->
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+
+  <div class="dorian-bar ep-bg">
+    <epc:if test="$item.has_type('image')">
+        <button class="dorian-bar-item dorian-button tablink ep-fg" onclick="openTab(event,'Images')" data-panel="Images">Images</button>
+    </epc:if>
+    <epc:if test="$item.has_type('video') or $item.url_is_video('official_url')">
+        <button class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Video')" data-panel="Video">Video</button>
+    </epc:if>
+    <epc:if test="$item.has_type('audio')">
+        <button class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Audio')" data-panel="Audio">Audio</button>
+    </epc:if>
+    <epc:if test="$item.has_docs() and ($item.has_type('image') or $item.has_type('video') or $item.has_type('audio'))">
+        <button class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Downloads')" data-panel="Downloads">Downloads</button>
+    </epc:if>
+    <epc:if test="($item.has_docs() and ($item.has_type('image') or $item.has_type('video') or $item.has_type('audio'))) or $item.url_is_video('official_url'))">
+        <button id="Metadata-button" class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Metadata')" data-panel="Metadata">Metadata</button>
+    </epc:if>
+</div>
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_tab_controls.xml
+++ b/lib/citations/eprint/dorian_tab_controls.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
 
-<!-- 
-	Full "abstract page" (or splash page or summary page, depending on your jargon) for an eprint. 
--->
-
-<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:epc="http://eprints.org/ep3/control" 
+    xmlns:cite="http://eprints.org/ep3/citation" >
 
   <div class="dorian-bar ep-bg">
     <epc:if test="$item.has_type('image')">

--- a/lib/citations/eprint/dorian_video_players_section.xml
+++ b/lib/citations/eprint/dorian_video_players_section.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+
+<!-- 
+	Full "abstract page" (or splash page or summary page, depending on your jargon) for an eprint. 
+-->
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+
+  <epc:set name='videos' expr="$item.get_type('video')">
+     <div id="Video" class="dorian-container dorian-border dorian-panel" style="display:none">
+	<!-- LOOP THROUGH ITEM VIDEO FILES and youtube/vimeo urls -->
+        <epc:foreach expr="$videos" iterator="video">
+          <div class="plyr_container">
+		<video id="plyr_{$index}" playsinline="true" controls="true" 
+			data-doc-title="{$video.property('main')}"
+			class="video">
+	     <source src="{$video.url()}" type="{$video.property('mime_type')}" />
+	       <!-- Captions are optional -->
+	       <!-- <track kind="captions" label="English captions" src="/path/to/captions.vtt" srclang="en" default />-->
+              </video>
+	  </div>
+        </epc:foreach>
+	<epc:if test="$item.property('official_url') and $item.url_is_video('official_url')">
+          <div class="plyr_container">
+	    <div class="plyr__video-embed" id="player_official_url">
+		<iframe
+			src="{$item.url_to_embed('official_url')}"
+		    allowfullscreen="true"
+		    allowtransparency="true"
+		    allow="autoplay"></iframe>
+	     </div>
+	   </div>
+	 </epc:if>
+     </div>
+  </epc:set> 
+
+</cite:citation>

--- a/lib/citations/eprint/dorian_videos.xml
+++ b/lib/citations/eprint/dorian_videos.xml
@@ -3,8 +3,9 @@
 <cite:citation xmlns="http://www.w3.org/1999/xhtml" 
     xmlns:epc="http://eprints.org/ep3/control" 
     xmlns:cite="http://eprints.org/ep3/citation" >
-
-    <epc:print expr="$item.citation('dorian_main_tabs_box')"/>
-    <epc:print expr="$item.citation('dorian_dependencies')"/>
+    
+    <epc:if test="$item.has_type('video') or $item.url_is_video('official_url')">
+        <epc:print expr="$item.citation('dorian_video_players_section')"/>
+    </epc:if>
 
 </cite:citation>

--- a/lib/citations/eprint/temp.xml
+++ b/lib/citations/eprint/temp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<!-- 
+	Full "abstract page" (or splash page or summary page, depending on your jargon) for an eprint. 
+-->
+
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
+
+
+</cite:citation>

--- a/lib/citations/eprint/temp.xml
+++ b/lib/citations/eprint/temp.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" ?>
-
-<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
-
-
-</cite:citation>

--- a/lib/citations/eprint/temp.xml
+++ b/lib/citations/eprint/temp.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" ?>
 
-<!-- 
-	Full "abstract page" (or splash page or summary page, depending on your jargon) for an eprint. 
--->
-
 <cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
 
 


### PR DESCRIPTION
As explained in #4 , the citation file was becoming large and hard to modify. 
This refactoring aims at making the citation more easily composable, customisable and of course, maintainable.

The idea is:
 
- the main dorian citation (dorian.xml) contains a reference to the structure of the main tabs box, and to the 2 main dependencies.

- the main tabs box (dorian_main_tabs_box.xml) contains the tabs controls section, and the various sections dependant on the file's mime_type

I notice that there is a bit of repetition here and there, so further refactoring is definitely possible - but for the moment this should make extending the plugin easier I hope.
