### PR TITLE
Soundcloud refactored

### DIFF
--- a/dorian.epmi
+++ b/dorian.epmi
@@ -17,9 +17,9 @@
           <datasetid>document</datasetid>
           <filename>cfg.d/zz_dorian.pl</filename>
           <mime_type>text/plain</mime_type>
-          <hash>fdd110632693b5b148fd3f7cb3f1b626</hash>
+          <hash>331bb3817d3b1a65bcf4837721ec51e1</hash>
           <hash_type>MD5</hash_type>
-          <filesize>4980</filesize>
+          <filesize>5383</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -28,14 +28,6 @@
           <hash>ca86472e6cb4b32a7fe45e82634790a9</hash>
           <hash_type>MD5</hash_type>
           <filesize>320</filesize>
-        </file>
-        <file>
-          <datasetid>document</datasetid>
-          <filename>citations/eprint/dorian_audios.xml</filename>
-          <mime_type>application/xml</mime_type>
-          <hash>ee7d4dbee4e239cb8f173cd0aec68c48</hash>
-          <hash_type>MD5</hash_type>
-          <filesize>325</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -111,14 +103,6 @@
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>citations/eprint/dorian_tab_controls.xml</filename>
-          <mime_type>application/xml</mime_type>
-          <hash>e22f38bc1be3eac211e8a3089e69eca0</hash>
-          <hash_type>MD5</hash_type>
-          <filesize>1454</filesize>
-        </file>
-        <file>
-          <datasetid>document</datasetid>
           <filename>citations/eprint/dorian_video_players_section.xml</filename>
           <mime_type>application/xml</mime_type>
           <hash>5f33d7a9b2f7138d09e179efb9624fc7</hash>
@@ -135,11 +119,27 @@
         </file>
         <file>
           <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_audios.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>4ed7269d972d0d55a781b7ab3654a13c</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>363</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_tab_controls.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>7cf7cfcb4f230ee3da2c078dbcd3a266</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>1492</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
           <filename>citations/eprint/dorian_audio_players_section.xml</filename>
           <mime_type>application/xml</mime_type>
-          <hash>98ab656c241b6df26be56157c60ae68a</hash>
+          <hash>821156af661f47c62dbe6685bba892df</hash>
           <hash_type>MD5</hash_type>
-          <filesize>861</filesize>
+          <filesize>1994</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -190,7 +190,7 @@
       <id>you@email.address</id>
     </item>
   </creators>
-  <datestamp>2019-11-15 16:23:36</datestamp>
+  <datestamp>2019-11-18 15:27:40</datestamp>
   <title>Dorian</title>
   <description>This is the description.</description>
   <requirements>The following modules are required: X, Y, Z</requirements>

--- a/dorian.epmi
+++ b/dorian.epmi
@@ -127,19 +127,19 @@
         </file>
         <file>
           <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_audio_players_section.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>1d8cd2a886138574c3395e42de3fd099</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>2426</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
           <filename>citations/eprint/dorian_tab_controls.xml</filename>
           <mime_type>application/xml</mime_type>
           <hash>7cf7cfcb4f230ee3da2c078dbcd3a266</hash>
           <hash_type>MD5</hash_type>
           <filesize>1492</filesize>
-        </file>
-        <file>
-          <datasetid>document</datasetid>
-          <filename>citations/eprint/dorian_audio_players_section.xml</filename>
-          <mime_type>application/xml</mime_type>
-          <hash>821156af661f47c62dbe6685bba892df</hash>
-          <hash_type>MD5</hash_type>
-          <filesize>1994</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -190,7 +190,7 @@
       <id>you@email.address</id>
     </item>
   </creators>
-  <datestamp>2019-11-18 15:27:40</datestamp>
+  <datestamp>2019-11-18 16:50:16</datestamp>
   <title>Dorian</title>
   <description>This is the description.</description>
   <requirements>The following modules are required: X, Y, Z</requirements>

--- a/dorian.epmi
+++ b/dorian.epmi
@@ -127,19 +127,19 @@
         </file>
         <file>
           <datasetid>document</datasetid>
-          <filename>citations/eprint/dorian_audio_players_section.xml</filename>
-          <mime_type>application/xml</mime_type>
-          <hash>1d8cd2a886138574c3395e42de3fd099</hash>
-          <hash_type>MD5</hash_type>
-          <filesize>2426</filesize>
-        </file>
-        <file>
-          <datasetid>document</datasetid>
           <filename>citations/eprint/dorian_tab_controls.xml</filename>
           <mime_type>application/xml</mime_type>
           <hash>7cf7cfcb4f230ee3da2c078dbcd3a266</hash>
           <hash_type>MD5</hash_type>
           <filesize>1492</filesize>
+        </file>
+        <file>
+          <datasetid>document</datasetid>
+          <filename>citations/eprint/dorian_audio_players_section.xml</filename>
+          <mime_type>application/xml</mime_type>
+          <hash>9f6a455c9bbd02f9daa74c5e41568dc6</hash>
+          <hash_type>MD5</hash_type>
+          <filesize>2430</filesize>
         </file>
         <file>
           <datasetid>document</datasetid>
@@ -190,7 +190,7 @@
       <id>you@email.address</id>
     </item>
   </creators>
-  <datestamp>2019-11-18 16:50:16</datestamp>
+  <datestamp>2019-11-18 16:59:43</datestamp>
   <title>Dorian</title>
   <description>This is the description.</description>
   <requirements>The following modules are required: X, Y, Z</requirements>

--- a/lib/cfg.d/zz_dorian.pl
+++ b/lib/cfg.d/zz_dorian.pl
@@ -174,3 +174,15 @@ sub run_iiif_manifest_enabled {
 	return [0, "BOOLEAN"]
 }
 
+
+sub run_url_is_audio {
+    my($self, $state, $eprint, $value) = @_;
+
+    if(!$eprint->[0]->isa("EPrints::DataObj::EPrint")) {
+        $self->runtime_error( 
+            "has_type() must be called on an eprint object. not : ".$eprint->[0] );
+    }
+    my $url = $eprint->[0]->get_value($value->[0]);
+    return [1, "BOOLEAN"] if $url =~ m#(http(s)?://(www\.)?)?soundcloud#;
+    return [0, "BOOLEAN"];
+}

--- a/lib/citations/eprint/dorian_audio_players_section.xml
+++ b/lib/citations/eprint/dorian_audio_players_section.xml
@@ -21,21 +21,30 @@
 
         <epc:if test="  $item.property('official_url') and 
                         $item.url_is_audio('official_url')">
-                        <iframe id="sc-widget" 
-                            width="100%" 
-                            height="166" 
-                            scrolling="no" 
-                            frameborder="no" 
-                            src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/293"></iframe>
+                        <div id="dorian_soundcloud_player"/>
+                        
                         <script src="https://w.soundcloud.com/player/api.js" 
                             type="text/javascript"></script>
                         <script type="text/javascript">
-                          (function(){
-                            var widgetIframe = document.getElementById('sc-widget'),
-                                widget       = SC.Widget(widgetIframe),
-                                newSoundUrl = "<epc:print expr= "$item.url_to_embed('official_url')"/>";
-                            widget.load(newSoundUrl, {show_artwork: false});
+                            //<![CDATA[
+                            soundcloud_url = "https://w.soundcloud.com/player/?url=";
+                            //]]>
+                            soundcloud_url += "<epc:print expr= "$item.url_to_embed('official_url')"/>";
+                            //<![CDATA[
+                            (function(){
+                            let iframe = document.createElement('iframe');
+                            iframe.id = "sc-widget";
+                            iframe.setAttribute("src", soundcloud_url);
+                            iframe.setAttribute("scrolling", "no");
+                            iframe.setAttribute("frameborder", "no");
+                            iframe.style.width = '100%';
+                            iframe.style.height = '166px';
+
+                            let soundcloud_player = document.getElementById('dorian_soundcloud_player');
+                            soundcloud_player.appendChild(iframe);
+                            let widget = SC.Widget(iframe);
                           }());
+                            //]]>
                       </script>
                   </epc:if>
       </div>

--- a/lib/citations/eprint/dorian_audio_players_section.xml
+++ b/lib/citations/eprint/dorian_audio_players_section.xml
@@ -27,7 +27,7 @@
                             type="text/javascript"></script>
                         <script type="text/javascript">
                             //<![CDATA[
-                            soundcloud_url = "https://w.soundcloud.com/player/?url=";
+                            let soundcloud_url = "https://w.soundcloud.com/player/?url=";
                             //]]>
                             soundcloud_url += "<epc:print expr= "$item.url_to_embed('official_url')"/>";
                             //<![CDATA[

--- a/lib/citations/eprint/dorian_audio_players_section.xml
+++ b/lib/citations/eprint/dorian_audio_players_section.xml
@@ -20,16 +20,15 @@
         </epc:foreach>
 
         <epc:if test="  $item.property('official_url') and 
-                        $item.url_is_audio('official_url')"> 
+                        $item.url_is_audio('official_url')">
                         <iframe id="sc-widget" 
                             width="100%" 
                             height="166" 
                             scrolling="no" 
                             frameborder="no" 
-                            src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/293"
-                            />
+                            src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/293"></iframe>
                         <script src="https://w.soundcloud.com/player/api.js" 
-                            type="text/javascript"/>
+                            type="text/javascript"></script>
                         <script type="text/javascript">
                           (function(){
                             var widgetIframe = document.getElementById('sc-widget'),

--- a/lib/citations/eprint/dorian_audio_players_section.xml
+++ b/lib/citations/eprint/dorian_audio_players_section.xml
@@ -18,8 +18,28 @@
      		</audio>
             </div>
         </epc:foreach>
-  </div>
-  </epc:set> 
 
+        <epc:if test="  $item.property('official_url') and 
+                        $item.url_is_audio('official_url')"> 
+                        <iframe id="sc-widget" 
+                            width="100%" 
+                            height="166" 
+                            scrolling="no" 
+                            frameborder="no" 
+                            src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/293"
+                            />
+                        <script src="https://w.soundcloud.com/player/api.js" 
+                            type="text/javascript"/>
+                        <script type="text/javascript">
+                          (function(){
+                            var widgetIframe = document.getElementById('sc-widget'),
+                                widget       = SC.Widget(widgetIframe),
+                                newSoundUrl = "<epc:print expr= "$item.url_to_embed('official_url')"/>";
+                            widget.load(newSoundUrl, {show_artwork: false});
+                          }());
+                      </script>
+                  </epc:if>
+      </div>
+  </epc:set> 
 
 </cite:citation>

--- a/lib/citations/eprint/dorian_audios.xml
+++ b/lib/citations/eprint/dorian_audios.xml
@@ -2,7 +2,7 @@
 <cite:citation xmlns="http://www.w3.org/1999/xhtml" 
     xmlns:epc="http://eprints.org/ep3/control" 
     xmlns:cite="http://eprints.org/ep3/citation" >
-    <epc:if test="$item.has_type('audio')">
+    <epc:if test="$item.has_type('audio') or $item.url_is_audio('official_url')">
         <epc:print expr="$item.citation('dorian_audio_players_section')"/>
     </epc:if>
 </cite:citation>

--- a/lib/citations/eprint/dorian_tab_controls.xml
+++ b/lib/citations/eprint/dorian_tab_controls.xml
@@ -11,7 +11,7 @@
     <epc:if test="$item.has_type('video') or $item.url_is_video('official_url')">
         <button class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Video')" data-panel="Video">Video</button>
     </epc:if>
-    <epc:if test="$item.has_type('audio')">
+    <epc:if test="$item.has_type('audio') or $item.url_is_audio('official_url')">
         <button class="dorian-bar-item dorian-button tablink" onclick="openTab(event,'Audio')" data-panel="Audio">Audio</button>
     </epc:if>
     <epc:if test="$item.has_docs() and ($item.has_type('image') or $item.has_type('video') or $item.has_type('audio'))">


### PR DESCRIPTION
refers to #6 

I added the possibility to add the Soundcloud player in case that the item has a Soundcloud URL as the value of the 'official_url'.

Potential improvements for the future:
- refactoring to move the JS code outside of the template as much as possible;
- Using the values of a (new) multifield to allow creating multiple iFrames for multiple Soudcloud files